### PR TITLE
FEAT:Route and Permissions Fix

### DIFF
--- a/servapps/2FAuth/docker-compose.yml
+++ b/servapps/2FAuth/docker-compose.yml
@@ -1,4 +1,4 @@
-cosmos-installer: null
+cosmos-installer: {}
 name: 2fauth
 services:
   "{ServiceName}":
@@ -7,14 +7,22 @@ services:
       resources:
         reservations:
           memory: 64M
-    network_mode: bridge
-    ports:
-      - 8000:8000/tcp
     restart: always
     volumes:
-      - type: bind
-        source: "{DefaultDataPath}/AppData/{ServiceName}"
+      - type: volume
+        source: "{ServiceName}-data"
         target: /2fauth
     container_name: "{ServiceName}"
     hostname: "{ServiceName}"
+    routes:
+      - name: "{ServiceName}"
+        description: Expose {ServiceName} to the web
+        useHost: true
+        target: http://{ServiceName}:8000
+        mode: SERVAPP
+        Timeout: 14400000
+        ThrottlePerMinute: 12000
+        BlockCommonBots: true
+        SmartShield:
+          Enabled: true
 minVersion: 0.14.0-0


### PR DESCRIPTION
Auto Configured Route
Permissions Avoidance by switching Bind to Volume.
Without this, you run into a restart loop with this error: https://github.com/Bubka/2FAuth/issues/210
because user 1000:1000 for some reason cant access the folder it is binded to.